### PR TITLE
docs: wire consent storage and bug reports for docs.coordinode.com

### DIFF
--- a/docs/.vitepress/theme/components/BugReportWidget.vue
+++ b/docs/.vitepress/theme/components/BugReportWidget.vue
@@ -54,7 +54,9 @@ async function submit() {
   errorMessage.value = "";
 
   try {
-    const response = await fetch("/api/report-bug", {
+    // Absolute URL: coordinode.com DNS is on PowerDNS (not Cloudflare), so the
+    // bug-reports worker is proxied through coordinode-docs.sw.foundation (CF zone).
+    const response = await fetch("https://coordinode-docs.sw.foundation/api/report-bug", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -14,7 +14,9 @@ const GA_ID = (import.meta.env as Record<string, string>).VITE_GA_ID || "";
 const consentTheme = enhanceWithConsent(DefaultTheme, {
   gaId: GA_ID,
   // KV storage via Cloudflare Worker (configured in R-DOC2 — bug-reports-worker)
-  storage: createKVStorage("/api/consent"),
+  // Absolute URL: coordinode.com DNS is on PowerDNS (not Cloudflare), so the
+  // consent worker is proxied through coordinode-docs.sw.foundation (CF zone).
+  storage: createKVStorage("https://coordinode-docs.sw.foundation/api/consent"),
 });
 
 export default {


### PR DESCRIPTION
## Summary
- `theme/index.ts`: `createKVStorage` uses absolute URL `https://coordinode-docs.sw.foundation/api/consent`
- `BugReportWidget.vue`: `fetch` uses absolute URL `https://coordinode-docs.sw.foundation/api/report-bug`

## Why a subdomain proxy?
`coordinode.com` DNS is on PowerDNS (not Cloudflare), so Cloudflare Worker zone routes for `docs.coordinode.com` are impossible. `coordinode-docs.sw.foundation` (in the `sw.foundation` CF zone) acts as API proxy — same pattern as `gitlab-mcp.sw.foundation` and `privacy.sw.foundation`.

Worker PRs:
- vue-privacy-worker: structured-world/vue-privacy-worker#54
- bug-reports-worker: structured-world/bug-reports-worker#35

Closes #7