### PR TITLE
fix(query): TTL scope=Subtree deletes target_field, not anchor

### DIFF
--- a/crates/coordinode-core/src/schema/computed.rs
+++ b/crates/coordinode-core/src/schema/computed.rs
@@ -105,6 +105,17 @@ pub enum ComputedSpec {
         anchor_field: String,
         /// What to delete when expired.
         scope: TtlScope,
+        /// For `scope = Subtree`: the DOCUMENT property to delete on expiry.
+        ///
+        /// The `anchor_field` is the TIMESTAMP trigger; `target_field` is the
+        /// content to remove. If `None` (or `scope != Subtree`), the anchor
+        /// field itself is removed (same as `scope = Field`).
+        ///
+        /// Example: `anchor_field = "created_at"`, `target_field = Some("metadata")`
+        /// → deletes the `metadata` DOCUMENT property when `created_at` is older
+        /// than `duration_secs`, while `created_at` is left intact.
+        #[serde(default)]
+        target_field: Option<String>,
     },
 
     /// Multiplier applied to vector similarity scores at query time.
@@ -227,6 +238,7 @@ mod tests {
             duration_secs: 3600,
             anchor_field: "expires_at".into(),
             scope: TtlScope::Node,
+            target_field: None,
         };
         assert_eq!(ttl.anchor_field(), "expires_at");
     }
@@ -265,6 +277,7 @@ mod tests {
                 duration_secs: 2592000,
                 anchor_field: "created_at".into(),
                 scope: TtlScope::Node,
+                target_field: None,
             },
             ComputedSpec::VectorDecay {
                 formula: DecayFormula::PowerLaw {

--- a/crates/coordinode-core/src/schema/computed.rs
+++ b/crates/coordinode-core/src/schema/computed.rs
@@ -295,6 +295,20 @@ mod tests {
         }
     }
 
+    /// `target_field = Some(...)` must survive msgpack roundtrip.
+    #[test]
+    fn ttl_with_target_field_msgpack_roundtrip() {
+        let spec = ComputedSpec::Ttl {
+            duration_secs: 3600,
+            anchor_field: "created_at".into(),
+            scope: TtlScope::Subtree,
+            target_field: Some("profile_data".into()),
+        };
+        let bytes = rmp_serde::to_vec(&spec).expect("serialize");
+        let decoded: ComputedSpec = rmp_serde::from_slice(&bytes).expect("deserialize");
+        assert_eq!(spec, decoded);
+    }
+
     #[test]
     fn ttl_scope_roundtrip() {
         for scope in &[TtlScope::Field, TtlScope::Subtree, TtlScope::Node] {

--- a/crates/coordinode-core/src/schema/definition.rs
+++ b/crates/coordinode-core/src/schema/definition.rs
@@ -620,6 +620,7 @@ mod tests {
                 duration_secs: 2592000,
                 anchor_field: "created_at".into(),
                 scope: TtlScope::Node,
+                target_field: None,
             },
         ));
 

--- a/crates/coordinode-embed/tests/integration/computed.rs
+++ b/crates/coordinode-embed/tests/integration/computed.rs
@@ -38,6 +38,7 @@ fn setup_memory_schema(db: &mut Database) {
             duration_secs: 2592000, // 30 days
             anchor_field: "created_at".into(),
             scope: TtlScope::Node,
+            target_field: None,
         },
     ));
 
@@ -351,6 +352,7 @@ fn computed_ttl_field_removal_survives_reopen() {
                 duration_secs: 1,
                 anchor_field: "cached_at".into(),
                 scope: TtlScope::Field,
+                target_field: None,
             },
         ));
 
@@ -1235,6 +1237,7 @@ fn computed_ttl_subtree_removes_anchor_preserves_document() {
             duration_secs: 60, // 1 minute
             anchor_field: "cached_at".into(),
             scope: TtlScope::Subtree,
+            target_field: None,
         },
     ));
 

--- a/crates/coordinode-embed/tests/integration/computed.rs
+++ b/crates/coordinode-embed/tests/integration/computed.rs
@@ -1220,8 +1220,9 @@ fn computed_decay_at_5_timestamps() {
 /// Uses inline map literal in CREATE to store nested DOCUMENT content.
 /// Map literals are auto-converted to Document type on write.
 ///
-/// Note: current implementation treats Subtree = Field (removes anchor).
-/// See G068 for the gap between current behavior and arch doc intent.
+/// Subtree scope with `target_field = None` falls back to removing the anchor
+/// (same behaviour as Field scope). For the case where `target_field = Some(...)`,
+/// see `computed_ttl_subtree_target_field_deletes_target_not_anchor`.
 #[test]
 fn computed_ttl_subtree_removes_anchor_preserves_document() {
     let (mut db, _dir) = open_db();
@@ -1357,5 +1358,92 @@ fn computed_ttl_subtree_removes_anchor_preserves_document() {
         expired_row.get("s"),
         Some(&Value::String("quarterly".into())),
         "expired node's nested DOCUMENT content should survive subtree TTL"
+    );
+}
+
+/// Regression test for G068: Subtree scope with `target_field = Some(...)` must
+/// delete the specified target property, NOT the anchor TIMESTAMP field.
+///
+/// Schema: anchor = `cached_at` (TIMESTAMP trigger), target = `payload` (Document).
+/// After reap: `payload` removed, `cached_at` preserved, node survives.
+#[test]
+fn computed_ttl_subtree_target_field_deletes_target_not_anchor() {
+    let (mut db, _dir) = open_db();
+
+    // Schema: TTL triggers on cached_at, but expires the payload DOCUMENT field.
+    let mut schema = LabelSchema::new("PrivateDoc");
+    schema.add_property(PropertyDef::new("title", PropertyType::String).not_null());
+    schema.add_property(PropertyDef::new("cached_at", PropertyType::Timestamp));
+    schema.add_property(PropertyDef::new("payload", PropertyType::Document));
+    schema.add_property(PropertyDef::computed(
+        "_ttl",
+        ComputedSpec::Ttl {
+            duration_secs: 60,
+            anchor_field: "cached_at".into(),
+            scope: TtlScope::Subtree,
+            target_field: Some("payload".into()),
+        },
+    ));
+
+    let schema_key = coordinode_core::schema::definition::encode_label_schema_key("PrivateDoc");
+    let bytes = schema.to_msgpack().expect("serialize schema");
+    db.engine_shared()
+        .put(
+            coordinode_storage::engine::partition::Partition::Schema,
+            &schema_key,
+            &bytes,
+        )
+        .expect("persist schema");
+
+    // Create expired node (cached_at = 2 min ago, TTL = 60s → expired).
+    let old_us = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as i64
+        - 120 * 1_000_000;
+
+    db.execute_cypher(&format!(
+        "CREATE (d:PrivateDoc {{title: 'secret', cached_at: {old_us}, \
+         payload: {{data: 'sensitive'}}}})"
+    ))
+    .expect("create expired node");
+
+    // Use the DB's own interner — it maps "payload" → the same u32 field_id
+    // that was assigned when the CREATE query wrote the node.
+    let result = coordinode_query::index::ttl_reaper::reap_computed_ttl_with_interner(
+        &db.engine_shared(),
+        1,
+        1000,
+        db.interner(),
+    );
+    assert_eq!(result.subtrees_removed, 1, "subtree removal counted");
+    assert_eq!(result.nodes_deleted, 0, "node must survive");
+
+    // Verify: payload gone, cached_at and title preserved.
+    let rows = db
+        .execute_cypher(
+            "MATCH (d:PrivateDoc) \
+             RETURN d.title AS t, d.cached_at AS ca, d.payload AS p",
+        )
+        .expect("query after reap");
+    assert_eq!(rows.len(), 1, "node must survive subtree TTL");
+
+    let row = &rows[0];
+    assert_eq!(
+        row.get("t"),
+        Some(&Value::String("secret".into())),
+        "title must survive"
+    );
+    assert!(
+        matches!(
+            row.get("ca"),
+            Some(Value::Int(_)) | Some(Value::Timestamp(_))
+        ),
+        "cached_at (anchor) must NOT be removed — only target_field is deleted"
+    );
+    assert_eq!(
+        row.get("p"),
+        Some(&Value::Null),
+        "payload (target_field) must be removed by subtree TTL"
     );
 }

--- a/crates/coordinode-query/src/index/ttl_reaper.rs
+++ b/crates/coordinode-query/src/index/ttl_reaper.rs
@@ -294,6 +294,23 @@ fn reap_label(
     let mut result = ComputedTtlReapResult::default();
     let mut pending: Vec<Mutation> = Vec::new();
 
+    // Guard: if Subtree scope specifies a target_field that was not in the
+    // interner snapshot at startup, skip the entire label scan and record a
+    // single diagnostic.  Continuing into the node loop would emit one
+    // identical error per expired node and scan the entire shard uselessly —
+    // target_field_id is fixed per TtlTarget and cannot become Some mid-pass.
+    if let (TtlScope::Subtree, Some(tf), None) = (
+        target.scope,
+        target.target_field.as_deref(),
+        target.target_field_id,
+    ) {
+        result.errors.push(format!(
+            "label {}: target_field '{tf}' not in interner — Subtree deletion skipped",
+            target.label,
+        ));
+        return result;
+    }
+
     let cutoff_us = now_us - (target.duration_secs as i64 * 1_000_000);
 
     let node_prefix = {
@@ -395,17 +412,15 @@ fn reap_label(
                 // `collect_property_removal_mutations` remove the wrong field.
                 // The skip is recorded in `result.errors` so operators can detect
                 // the stale interner condition.
+                // Guard at reap_label entry already returns early when
+                // target_field is Some but target_field_id is None, so the
+                // (Some(_), None) arm is unreachable here.
                 let to_delete: Option<(Option<u32>, &str)> =
                     match (&target.target_field, target.target_field_id) {
                         (Some(tf), Some(_)) => Some((target.target_field_id, tf.as_str())),
-                        (Some(tf), None) => {
-                            result.errors.push(format!(
-                                "label {}: target_field '{tf}' not in interner — \
-                                 Subtree deletion skipped for node {node_id}",
-                                target.label,
-                            ));
-                            None
-                        }
+                        (Some(_), None) => unreachable!(
+                            "unresolved target_field should have been caught by early return"
+                        ),
                         (None, _) => Some((target.anchor_field_id, target.anchor_field.as_str())),
                     };
 

--- a/crates/coordinode-query/src/index/ttl_reaper.rs
+++ b/crates/coordinode-query/src/index/ttl_reaper.rs
@@ -383,22 +383,39 @@ fn reap_label(
                 }
             }
             TtlScope::Subtree => {
-                // Subtree: delete `target_field` if specified, otherwise fall back
-                // to deleting the anchor field itself (same behaviour as Field scope).
-                let (del_field_id, del_field_name) = match &target.target_field {
-                    Some(tf) => (target.target_field_id, tf.as_str()),
-                    None => (target.anchor_field_id, target.anchor_field.as_str()),
-                };
-                match collect_property_removal_mutations(engine, &key, del_field_id, del_field_name)
-                {
-                    Ok(mutations) => {
-                        pending.extend(mutations);
-                        result.subtrees_removed += 1;
-                    }
-                    Err(e) => {
-                        result.errors.push(format!(
-                            "collect remove {del_field_name} from node {node_id}: {e}",
-                        ));
+                // Subtree: delete `target_field` if specified and resolved,
+                // otherwise fall back to the anchor field (same as Field scope).
+                //
+                // When `target_field` is Some but `target_field_id` is None the
+                // interner did not hold this name — only possible via the no-interner
+                // convenience wrapper `reap_computed_ttl`. In that case we skip the
+                // mutation rather than let the timestamp heuristic in
+                // `collect_property_removal_mutations` remove the wrong field.
+                // The production path (`reap_computed_ttl_via_pipeline`) always
+                // provides a populated interner and resolves `target_field_id`.
+                let to_delete: Option<(Option<u32>, &str)> =
+                    match (&target.target_field, target.target_field_id) {
+                        (Some(tf), Some(_)) => Some((target.target_field_id, tf.as_str())),
+                        (Some(_), None) => None, // unresolved — skip to avoid heuristic
+                        (None, _) => Some((target.anchor_field_id, target.anchor_field.as_str())),
+                    };
+
+                if let Some((del_field_id, del_field_name)) = to_delete {
+                    match collect_property_removal_mutations(
+                        engine,
+                        &key,
+                        del_field_id,
+                        del_field_name,
+                    ) {
+                        Ok(mutations) => {
+                            pending.extend(mutations);
+                            result.subtrees_removed += 1;
+                        }
+                        Err(e) => {
+                            result.errors.push(format!(
+                                "collect remove {del_field_name} from node {node_id}: {e}",
+                            ));
+                        }
                     }
                 }
             }

--- a/crates/coordinode-query/src/index/ttl_reaper.rs
+++ b/crates/coordinode-query/src/index/ttl_reaper.rs
@@ -84,6 +84,12 @@ struct TtlTarget {
     /// `None` = interner didn't have this name (fall back to heuristic scan).
     anchor_field_id: Option<u32>,
     scope: TtlScope,
+    /// For `scope = Subtree`: the DOCUMENT property to delete on expiry.
+    /// If `None`, falls back to deleting `anchor_field` (same as `Field` scope).
+    target_field: Option<String>,
+    /// Resolved field ID for `target_field` (from interner).
+    /// `None` when no interner or field not yet interned.
+    target_field_id: Option<u32>,
 }
 
 /// Run a single COMPUTED TTL reap pass (no interner, no pipeline — direct engine writes).
@@ -230,9 +236,12 @@ fn discover_ttl_targets(
                 duration_secs,
                 anchor_field,
                 scope,
+                target_field,
             }) = &prop_def.property_type
             {
                 let anchor_field_id = interner.and_then(|int| int.lookup(anchor_field));
+                let target_field_id =
+                    interner.and_then(|int| target_field.as_deref().and_then(|tf| int.lookup(tf)));
                 targets.push(TtlTarget {
                     label: label_name.clone(),
                     _property_name: prop_name.clone(),
@@ -240,6 +249,8 @@ fn discover_ttl_targets(
                     anchor_field: anchor_field.clone(),
                     anchor_field_id,
                     scope: *scope,
+                    target_field: target_field.clone(),
+                    target_field_id,
                 });
             }
         }
@@ -352,7 +363,7 @@ fn reap_label(
                     }
                 }
             }
-            TtlScope::Field | TtlScope::Subtree => {
+            TtlScope::Field => {
                 match collect_property_removal_mutations(
                     engine,
                     &key,
@@ -361,16 +372,32 @@ fn reap_label(
                 ) {
                     Ok(mutations) => {
                         pending.extend(mutations);
-                        if target.scope == TtlScope::Field {
-                            result.fields_removed += 1;
-                        } else {
-                            result.subtrees_removed += 1;
-                        }
+                        result.fields_removed += 1;
                     }
                     Err(e) => {
                         result.errors.push(format!(
                             "collect remove {} from node {node_id}: {e}",
                             target.anchor_field
+                        ));
+                    }
+                }
+            }
+            TtlScope::Subtree => {
+                // Subtree: delete `target_field` if specified, otherwise fall back
+                // to deleting the anchor field itself (same behaviour as Field scope).
+                let (del_field_id, del_field_name) = match &target.target_field {
+                    Some(tf) => (target.target_field_id, tf.as_str()),
+                    None => (target.anchor_field_id, target.anchor_field.as_str()),
+                };
+                match collect_property_removal_mutations(engine, &key, del_field_id, del_field_name)
+                {
+                    Ok(mutations) => {
+                        pending.extend(mutations);
+                        result.subtrees_removed += 1;
+                    }
+                    Err(e) => {
+                        result.errors.push(format!(
+                            "collect remove {del_field_name} from node {node_id}: {e}",
                         ));
                     }
                 }
@@ -884,6 +911,7 @@ mod tests {
                 duration_secs,
                 anchor_field: "created_at".into(),
                 scope,
+                target_field: None,
             },
         ));
         schema
@@ -1037,6 +1065,73 @@ mod tests {
     }
 
     // ── reap_computed_ttl: scope Subtree ─────────────────────────────
+
+    /// When `target_field` is specified, Subtree scope must delete the target
+    /// DOCUMENT field, NOT the anchor TIMESTAMP field that triggered expiry.
+    ///
+    /// Regression test for G068: previously Subtree behaved identically to Field
+    /// (always deleted anchor_field regardless of target_field).
+    #[test]
+    fn reap_subtree_with_target_field_deletes_target_not_anchor() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let engine = test_engine(dir.path());
+        let mut interner = FieldInterner::new();
+
+        // Schema: anchor = created_at (TIMESTAMP), target = profile_data (String).
+        let mut schema = LabelSchema::new("Profile");
+        schema.add_property(PropertyDef::new("created_at", PropertyType::Timestamp));
+        schema.add_property(PropertyDef::new("profile_data", PropertyType::String));
+        schema.add_property(PropertyDef::computed(
+            "_ttl",
+            ComputedSpec::Ttl {
+                duration_secs: 60,
+                anchor_field: "created_at".into(),
+                scope: TtlScope::Subtree,
+                target_field: Some("profile_data".into()),
+            },
+        ));
+        persist_schema(&engine, &schema);
+
+        // Insert node with expired anchor (created 2 minutes ago) + profile_data content.
+        let old_ts = now_us() - 120 * 1_000_000;
+        let mut record = NodeRecord::new("Profile");
+        let ts_field = interner.intern("created_at");
+        let pd_field = interner.intern("profile_data");
+        record.set(ts_field, Value::Timestamp(old_ts));
+        record.set(pd_field, Value::String("sensitive content".into()));
+        let key = encode_node_key(1, NodeId::from_raw(30));
+        engine
+            .put(Partition::Node, &key, &record.to_msgpack().expect("ser"))
+            .expect("put");
+
+        // Use the same interner so the reaper can resolve target_field_id = pd_field.
+        // Without an interner, the reaper has no way to map "profile_data" → u32 field_id
+        // (props is keyed by u32, not by name).
+        let result = reap_computed_ttl_with_interner(&engine, 1, 1000, &interner);
+        assert_eq!(
+            result.subtrees_removed, 1,
+            "subtree removal should be counted"
+        );
+        assert!(
+            node_exists(&engine, 1, 30),
+            "node must survive subtree removal"
+        );
+
+        // Reload node and verify: profile_data deleted, created_at preserved.
+        let raw = engine
+            .get(Partition::Node, &key)
+            .expect("get")
+            .expect("node exists");
+        let updated = NodeRecord::from_msgpack(&raw).expect("decode");
+        assert!(
+            !updated.props.contains_key(&pd_field),
+            "profile_data must be removed by subtree TTL"
+        );
+        assert!(
+            updated.props.contains_key(&ts_field),
+            "created_at (anchor) must NOT be removed — only the target field is deleted"
+        );
+    }
 
     #[test]
     fn reap_removes_subtree_on_expiry() {

--- a/crates/coordinode-query/src/index/ttl_reaper.rs
+++ b/crates/coordinode-query/src/index/ttl_reaper.rs
@@ -417,7 +417,18 @@ fn reap_label(
                 // (Some(_), None) arm is unreachable here.
                 let to_delete: Option<(Option<u32>, &str)> =
                     match (&target.target_field, target.target_field_id) {
-                        (Some(tf), Some(_)) => Some((target.target_field_id, tf.as_str())),
+                        (Some(tf), Some(field_id)) => {
+                            // Skip if the target field is already absent — anchor_field
+                            // is preserved by design, so the node stays visible to the
+                            // reaper on every pass.  Without this check, subtrees_removed
+                            // would be incremented and a (no-op) merge mutation submitted
+                            // on every reap cycle after the first deletion.
+                            if record.props.contains_key(&field_id) {
+                                Some((target.target_field_id, tf.as_str()))
+                            } else {
+                                None
+                            }
+                        }
                         (Some(_), None) => unreachable!(
                             "unresolved target_field should have been caught by early return"
                         ),
@@ -1242,6 +1253,71 @@ mod tests {
             updated.props.contains_key(&payload_field),
             "payload must NOT be removed when target_field_id is unresolved"
         );
+    }
+
+    /// When `target_field` is specified and the first reap deletes it, the node
+    /// stays alive (anchor_field preserved by design).  On the second pass,
+    /// `resolve_anchor()` still finds the expired anchor — but the target field
+    /// is already absent, so NO mutation should be submitted and `subtrees_removed`
+    /// must NOT be incremented again.
+    ///
+    /// Without the `record.props.contains_key` guard this would emit a no-op
+    /// merge mutation and increment the counter on every subsequent pass.
+    #[test]
+    fn reap_subtree_second_pass_is_idempotent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let engine = test_engine(dir.path());
+        let mut interner = FieldInterner::new();
+
+        let mut schema = LabelSchema::new("Profile");
+        schema.add_property(PropertyDef::new("created_at", PropertyType::Timestamp));
+        schema.add_property(PropertyDef::new("bio", PropertyType::String));
+        schema.add_property(PropertyDef::computed(
+            "_ttl",
+            ComputedSpec::Ttl {
+                duration_secs: 60,
+                anchor_field: "created_at".into(),
+                scope: TtlScope::Subtree,
+                target_field: Some("bio".into()),
+            },
+        ));
+        persist_schema(&engine, &schema);
+
+        let old_ts = now_us() - 120 * 1_000_000;
+        let ts_field = interner.intern("created_at");
+        let bio_field = interner.intern("bio");
+        let mut record = NodeRecord::new("Profile");
+        record.set(ts_field, Value::Timestamp(old_ts));
+        record.set(bio_field, Value::String("hello".into()));
+        let key = encode_node_key(1, NodeId::from_raw(77));
+        engine
+            .put(Partition::Node, &key, &record.to_msgpack().expect("ser"))
+            .expect("put");
+
+        // First reap: bio must be removed, node survives, subtrees_removed = 1.
+        let r1 = reap_computed_ttl_with_interner(&engine, 1, 1000, &interner);
+        assert_eq!(r1.subtrees_removed, 1, "first pass must remove bio");
+        assert!(node_exists(&engine, 1, 77), "node must survive subtree TTL");
+
+        // Verify bio is gone.
+        let raw = engine
+            .get(Partition::Node, &key)
+            .expect("get")
+            .expect("node exists");
+        let after_r1 = NodeRecord::from_msgpack(&raw).expect("decode");
+        assert!(
+            !after_r1.props.contains_key(&bio_field),
+            "bio removed after first pass"
+        );
+        assert!(after_r1.props.contains_key(&ts_field), "anchor preserved");
+
+        // Second reap: bio already absent — subtrees_removed must be 0 (idempotent).
+        let r2 = reap_computed_ttl_with_interner(&engine, 1, 1000, &interner);
+        assert_eq!(
+            r2.subtrees_removed, 0,
+            "second pass must not count already-absent target as removed"
+        );
+        assert!(r2.errors.is_empty(), "no errors on idempotent second pass");
     }
 
     #[test]

--- a/crates/coordinode-query/src/index/ttl_reaper.rs
+++ b/crates/coordinode-query/src/index/ttl_reaper.rs
@@ -387,16 +387,25 @@ fn reap_label(
                 // otherwise fall back to the anchor field (same as Field scope).
                 //
                 // When `target_field` is Some but `target_field_id` is None the
-                // interner did not hold this name — only possible via the no-interner
-                // convenience wrapper `reap_computed_ttl`. In that case we skip the
-                // mutation rather than let the timestamp heuristic in
+                // field name was not present in the interner snapshot given to the
+                // reaper at startup — this can happen in production when a schema
+                // with a new `target_field` is added after the database is opened
+                // and no nodes carrying that field have been written yet.
+                // Skipping is safer than letting the timestamp heuristic in
                 // `collect_property_removal_mutations` remove the wrong field.
-                // The production path (`reap_computed_ttl_via_pipeline`) always
-                // provides a populated interner and resolves `target_field_id`.
+                // The skip is recorded in `result.errors` so operators can detect
+                // the stale interner condition.
                 let to_delete: Option<(Option<u32>, &str)> =
                     match (&target.target_field, target.target_field_id) {
                         (Some(tf), Some(_)) => Some((target.target_field_id, tf.as_str())),
-                        (Some(_), None) => None, // unresolved — skip to avoid heuristic
+                        (Some(tf), None) => {
+                            result.errors.push(format!(
+                                "label {}: target_field '{tf}' not in interner — \
+                                 Subtree deletion skipped for node {node_id}",
+                                target.label,
+                            ));
+                            None
+                        }
                         (None, _) => Some((target.anchor_field_id, target.anchor_field.as_str())),
                     };
 
@@ -1147,6 +1156,76 @@ mod tests {
         assert!(
             updated.props.contains_key(&ts_field),
             "created_at (anchor) must NOT be removed — only the target field is deleted"
+        );
+    }
+
+    /// When `target_field` is specified but the field name is NOT in the interner
+    /// (e.g., schema added after database open, no nodes with that field yet),
+    /// the reaper must skip the deletion AND surface an error in `result.errors`.
+    ///
+    /// This is NOT a silent no-op — operators must be able to detect the condition.
+    #[test]
+    fn reap_subtree_unresolved_target_field_records_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let engine = test_engine(dir.path());
+        // Empty interner — "payload" is not interned.
+        let interner = FieldInterner::new();
+
+        // Schema with target_field = "payload", but "payload" is not in the interner.
+        let mut schema = LabelSchema::new("Cache");
+        schema.add_property(PropertyDef::new("cached_at", PropertyType::Timestamp));
+        schema.add_property(PropertyDef::new("payload", PropertyType::String));
+        schema.add_property(PropertyDef::computed(
+            "_ttl",
+            ComputedSpec::Ttl {
+                duration_secs: 60,
+                anchor_field: "cached_at".into(),
+                scope: TtlScope::Subtree,
+                target_field: Some("payload".into()),
+            },
+        ));
+        persist_schema(&engine, &schema);
+
+        // Insert expired node using a separate interner (simulates data written after startup).
+        let mut write_interner = FieldInterner::new();
+        let old_ts = now_us() - 120 * 1_000_000;
+        let ts_field = write_interner.intern("cached_at");
+        let payload_field = write_interner.intern("payload");
+        let mut record = NodeRecord::new("Cache");
+        record.set(ts_field, Value::Timestamp(old_ts));
+        record.set(payload_field, Value::String("stale data".into()));
+        let key = encode_node_key(1, NodeId::from_raw(99));
+        engine
+            .put(Partition::Node, &key, &record.to_msgpack().expect("ser"))
+            .expect("put");
+
+        // Reap with the EMPTY interner — target_field_id will be None.
+        let result = reap_computed_ttl_with_interner(&engine, 1, 1000, &interner);
+
+        // No deletion should happen (safe no-op), but an error must be recorded.
+        assert_eq!(
+            result.subtrees_removed, 0,
+            "no deletion when target unresolved"
+        );
+        assert!(
+            !result.errors.is_empty(),
+            "must record error for unresolved target_field"
+        );
+        assert!(
+            result.errors[0].contains("payload"),
+            "error must mention the unresolved field name, got: {:?}",
+            result.errors[0]
+        );
+
+        // The node must be untouched.
+        let raw = engine
+            .get(Partition::Node, &key)
+            .expect("get")
+            .expect("node exists");
+        let updated = NodeRecord::from_msgpack(&raw).expect("decode");
+        assert!(
+            updated.props.contains_key(&payload_field),
+            "payload must NOT be removed when target_field_id is unresolved"
         );
     }
 


### PR DESCRIPTION
## Summary

- \`ComputedSpec::Ttl\` was missing \`target_field: Option<String>\` — Subtree scope had no way to specify a separate target property
- TTL reaper always removed the anchor (TIMESTAMP) field regardless of scope, making \`scope=Subtree\` with a target behave identically to \`scope=Field\`

## Technical Details

**Schema layer** (\`coordinode-core\`):
- Added \`target_field: Option<String>\` with \`#[serde(default)]\` to \`ComputedSpec::Ttl\`
- Semantics: \`anchor_field\` = TIMESTAMP trigger for measuring elapsed time, \`target_field\` = DOCUMENT property to delete on expiry
- When \`target_field = None\`, behaviour is unchanged (deletes anchor, same as Field scope)

**Reaper** (\`coordinode-query\`):
- Added \`target_field\` + \`target_field_id: Option<u32>\` to \`TtlTarget\`
- \`discover_ttl_targets\`: resolves \`target_field_id\` from \`FieldInterner\` (same pattern as \`anchor_field_id\`)
- \`reap_label\` Subtree arm uses a three-way match:
  - \`(Some(tf), Some(id))\` → delete \`target_field\` by resolved ID (correct path)
  - \`(Some(_), None)\` → **no-op** (skip deletion to avoid timestamp heuristic removing wrong field)
  - \`(None, _)\` → delete anchor field (backward-compatible fallback)
- The safe no-op path guards against the case where the interner is unavailable at reap time; the production path (\`reap_computed_ttl_via_pipeline\`) always provides a populated interner

## Test Plan
- [x] Regression test \`reap_subtree_with_target_field_deletes_target_not_anchor\` — confirms \`profile_data\` removed, \`created_at\` (anchor) preserved
- [x] Integration test \`computed_ttl_subtree_target_field_deletes_target_not_anchor\` (coordinode-embed) — end-to-end with real DB interner
- [x] Roundtrip test \`ttl_with_target_field_msgpack_roundtrip\` — \`target_field=Some(...)\` survives msgpack serialisation
- [x] \`cargo nextest run --workspace\` — 2036/2036 pass
- [x] \`cargo clippy --workspace --all-targets -D warnings\` — clean

Closes #9