### PR TITLE
fix(raft): update NetBackoff::backoff() return type to Option<Backoff>

### DIFF
--- a/crates/coordinode-raft/src/cluster/network.rs
+++ b/crates/coordinode-raft/src/cluster/network.rs
@@ -136,10 +136,10 @@ impl GrpcNetwork {
 }
 
 impl NetBackoff<C> for GrpcNetwork {
-    fn backoff(&self) -> Backoff {
+    fn backoff(&self) -> Option<Backoff> {
         // Infinite 200ms backoff (matches openraft default).
         // openraft enables backoff after 20 consecutive errors.
-        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+        Some(Backoff::new(std::iter::repeat(Duration::from_millis(200))))
     }
 }
 
@@ -327,8 +327,8 @@ impl NetTransferLeader<C> for GrpcNetwork {
 pub struct StubNetwork;
 
 impl NetBackoff<C> for StubNetwork {
-    fn backoff(&self) -> Backoff {
-        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+    fn backoff(&self) -> Option<Backoff> {
+        Some(Backoff::new(std::iter::repeat(Duration::from_millis(200))))
     }
 }
 


### PR DESCRIPTION
## Summary

- `openraft 0.10.0-alpha.18` changed `NetBackoff` trait: `backoff()` now returns `Option<Backoff>` instead of `Backoff`
- Both `GrpcNetwork` and `StubNetwork` impls updated to return `Some(Backoff::new(...))`
- Without this fix, `coordinode-python` CI fails when cargo resolves to `alpha.18+` (Cargo.lock is gitignored in coordinode-embedded)

Closes #39